### PR TITLE
Add simple setOutputs tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "changeoverswitch",
+  "version": "1.0.0",
+  "description": "This script enables **changeover switch** functionality for the **Shelly 2PM**, providing seamless integration between switches and smart home systems like Alexa.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/testSetOutputs.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/setOutputs.js
+++ b/setOutputs.js
@@ -1,0 +1,20 @@
+const shelly = {
+  crossed: false,
+  input: {"0": {state: false}, "1": {state: false}},
+  output: {"0": {state: false}, "1": {state: false}}
+};
+
+let switchOut = false;
+
+function setOutputs(){
+  if(!shelly.crossed){
+    shelly.output["0"].state = shelly.input["0"].state;
+    shelly.output["1"].state = shelly.input["1"].state;
+  }else{
+    shelly.output["0"].state = shelly.input["1"].state;
+    shelly.output["1"].state = shelly.input["0"].state;
+  }
+  switchOut = true;
+}
+
+module.exports = { shelly, setOutputs };

--- a/tests/testSetOutputs.js
+++ b/tests/testSetOutputs.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { shelly, setOutputs } = require('../setOutputs');
+
+function resetModel(){
+  shelly.crossed = false;
+  shelly.input['0'].state = false;
+  shelly.input['1'].state = false;
+  shelly.output['0'].state = false;
+  shelly.output['1'].state = false;
+}
+
+function test_not_crossed(){
+  resetModel();
+  shelly.crossed = false;
+  shelly.input['0'].state = true;
+  shelly.input['1'].state = false;
+  setOutputs();
+  assert.strictEqual(shelly.output['0'].state, shelly.input['0'].state, 'output[0] should follow input[0]');
+  assert.strictEqual(shelly.output['1'].state, shelly.input['1'].state, 'output[1] should follow input[1]');
+}
+
+function test_crossed(){
+  resetModel();
+  shelly.crossed = true;
+  shelly.input['0'].state = true;
+  shelly.input['1'].state = false;
+  setOutputs();
+  assert.strictEqual(shelly.output['0'].state, shelly.input['1'].state, 'output[0] should follow input[1]');
+  assert.strictEqual(shelly.output['1'].state, shelly.input['0'].state, 'output[1] should follow input[0]');
+}
+
+function run(){
+  test_not_crossed();
+  test_crossed();
+  console.log('All tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- set up minimal Node.js project
- provide `setOutputs` function in a module for testing
- add basic tests for `setOutputs` logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e78bb94e0832ebd1b894829f8afec